### PR TITLE
Small Arsenal update / TMF Respawn fix / A3 Stamina disable

### DIFF
--- a/loadouts/arsenal.sqf
+++ b/loadouts/arsenal.sqf
@@ -70,6 +70,11 @@ private _itemEquipment =
 	//Vests
 	//============================================================
 	"V_PlateCarrier2_blk",
+	"V_PlateCarrier2_rgr_noflag_F",
+	"V_PlateCarrier1_blk",
+	"V_PlateCarrier1_rgr_noflag_F",
+	"CUP_V_CZ_NPP2006_nk_black",
+	"CUP_V_CZ_NPP2006_nk_vz95",
 	
 	//============================================================
 	//Backpacks
@@ -327,6 +332,7 @@ private _itemWeaponPistol =
 	"greenmag_ammo_9x21_basic_30Rnd",
 	"greenmag_ammo_45ACP_basic_30Rnd",
 	"greenmag_ammo_9x18_basic_30Rnd",
+	"greenmag_ammo_762x25_ball_30Rnd",
 
 	//Attachments
 	"cup_acc_mk23_lam_f",
@@ -351,6 +357,8 @@ private _itemLeaderEquipment =
 	"optic_mrd_black",
 	"muzzle_snds_l",
 	"cup_muzzle_snds_mk23",
+	
+	"greenmag_ammo_50AE_ball_30Rnd", // deagle rounds
 
 	//Hats
 	"H_Beret_blk",

--- a/loadouts/player_loadout.hpp
+++ b/loadouts/player_loadout.hpp
@@ -6,6 +6,9 @@
 		- Removed all ACRE radios
 		- Added tracers to Leader and AR roles
 	Edited by Beagle on 2021-08-24
+	Edited by Alien314 on 2021-12-10
+	  Changenotes: 
+		- Added code to initialize players/respawns, disabling base game stamina and adding APS plates and actions.	    
 */
 
 // Weaponless Baseclass
@@ -145,7 +148,7 @@ class basetrooper
 	backpackItems[] = {};
 	
 	// This is executed after the unit init is complete. Argument: _this = _unit.
-	code = "";
+	code = "[_this] spawn { params [""_player""]; waitUntil {isPlayer _player}; _player enableStamina false; _player enableFatigue false; _player call diw_armor_plates_main_fnc_fillVestWithPlates; _player call diw_armor_plates_main_fnc_addActionsToUnit; _player call diw_armor_plates_main_fnc_addPlayerHoldActions;}";
 };
 
 


### PR DESCRIPTION
Uses TMF loadout system to give initPlayerLocal type stuff to Respawns, including disabling A3 stamina if ACE Adv. Fatigue is off.